### PR TITLE
fix: increase the location failure count

### DIFF
--- a/terraform/synthetics/variables.tf
+++ b/terraform/synthetics/variables.tf
@@ -79,7 +79,7 @@ locals {
   # default options that most tests share
   default_options = {
     tick_every          = 60
-    min_location_failed = 1
+    min_location_failed = 5
     retry_count         = 1
     retry_interval      = 300
   }


### PR DESCRIPTION
for this failure, https://app.datadoghq.com/synthetics/details/cc9-qga-nu4?refresh_mode=paused&from_ts=1754388589125&to_ts=1754388613865&live=false, only one location failed for whatever reason, but i don't think we should trigger a whole 5am alert unless a significant impact to pops happen

for reduced and america locations in our variables.tf, this is 1/5 of locations to constitute a failure.. for all locations its ~20%